### PR TITLE
hook `window-scroll-functions' also

### DIFF
--- a/vim-empty-lines-mode.el
+++ b/vim-empty-lines-mode.el
@@ -124,19 +124,18 @@ Must not contain '\\n'."
                                               t t))
   (overlay-put vim-empty-lines-overlay 'window t))
 
-(defun vim-empty-lines-update-overlay (&optional window window-start)
+(defun vim-empty-lines-update-overlay (&optional window _window-start)
   (let ((w (or window
                (let ((w (get-buffer-window)))
                  (and (window-valid-p w) w)))))
     ;; `w' could be nil but it's ok for `window-height' and `window-start'.
-    (vim-empty-lines-update-overlay-aux (window-height w)
-                                        (or window-start (window-start w)))))
+    (vim-empty-lines-update-overlay-aux w)))
 
-(defun vim-empty-lines-update-overlay-aux (window-height window-start)
+(defun vim-empty-lines-update-overlay-aux (window)
   (when (overlayp vim-empty-lines-overlay)
-    (let* ((nlines-after-buffer-end (- window-height
+    (let* ((nlines-after-buffer-end (- (window-height window)
                                        (- (line-number-at-pos (point-max))
-                                          (line-number-at-pos window-start)))))
+                                          (line-number-at-pos (window-start window))))))
       (save-excursion
         (when (> nlines-after-buffer-end 1)
           (let ((indicators

--- a/vim-empty-lines-mode.el
+++ b/vim-empty-lines-mode.el
@@ -124,6 +124,11 @@ Must not contain '\\n'."
                                               t t))
   (overlay-put vim-empty-lines-overlay 'window t))
 
+(defun vim-empty-lines-nlines-after-buffer-end (window)
+  (- (window-height window)
+     (- (line-number-at-pos (point-max))
+        (line-number-at-pos (window-start window)))))
+
 (defun vim-empty-lines-update-overlay (&optional window _window-start)
   (let ((w (or window
                (let ((w (get-buffer-window)))
@@ -133,9 +138,7 @@ Must not contain '\\n'."
 
 (defun vim-empty-lines-update-overlay-aux (window)
   (when (overlayp vim-empty-lines-overlay)
-    (let* ((nlines-after-buffer-end (- (window-height window)
-                                       (- (line-number-at-pos (point-max))
-                                          (line-number-at-pos (window-start window))))))
+    (let* ((nlines-after-buffer-end (vim-empty-lines-nlines-after-buffer-end window)))
       (save-excursion
         (when (> nlines-after-buffer-end 1)
           (let ((indicators

--- a/vim-empty-lines-mode.el
+++ b/vim-empty-lines-mode.el
@@ -124,11 +124,19 @@ Must not contain '\\n'."
                                               t t))
   (overlay-put vim-empty-lines-overlay 'window t))
 
-(defun vim-empty-lines-update-overlay ()
+(defun vim-empty-lines-update-overlay (&optional window window-start)
+  (let ((w (or window
+               (let ((w (get-buffer-window)))
+                 (and (window-valid-p w) w)))))
+    ;; `w' could be nil but it's ok for `window-height' and `window-start'.
+    (vim-empty-lines-update-overlay-aux (window-height w)
+                                        (or window-start (window-start w)))))
+
+(defun vim-empty-lines-update-overlay-aux (window-height window-start)
   (when (overlayp vim-empty-lines-overlay)
-    (let* ((nlines-after-buffer-end (- (window-height)
+    (let* ((nlines-after-buffer-end (- window-height
                                        (- (line-number-at-pos (point-max))
-                                          (line-number-at-pos (window-start))))))
+                                          (line-number-at-pos window-start)))))
       (save-excursion
         (when (> nlines-after-buffer-end 1)
           (let ((indicators
@@ -165,8 +173,10 @@ with trailing newlines."
         (make-local-variable 'vim-empty-lines-overlay)
         (vim-empty-lines-create-overlay)
         (vim-empty-lines-update-overlay)
-        (add-hook 'post-command-hook 'vim-empty-lines-update-overlay t))
+        (add-hook 'post-command-hook 'vim-empty-lines-update-overlay t)
+        (add-hook 'window-scroll-functions 'vim-empty-lines-update-overlay t))
     (remove-hook 'post-command-hook 'vim-empty-lines-update-overlay t)
+    (remove-hook 'window-scroll-functions 'vim-empty-lines-update-overlay t)
     (when (overlayp vim-empty-lines-overlay)
       (delete-overlay vim-empty-lines-overlay)
       (setq vim-empty-lines-overlay nil))))

--- a/vim-empty-lines-mode.el
+++ b/vim-empty-lines-mode.el
@@ -133,27 +133,28 @@ Must not contain '\\n'."
   (let ((w (or window
                (let ((w (get-buffer-window)))
                  (and (window-valid-p w) w)))))
-    ;; `w' could be nil but it's ok for `window-height' and `window-start'.
-    (vim-empty-lines-update-overlay-aux w)))
+    ;; `w' could be nil but it's ok for `window-height', `window-start' etc.
+    (with-current-buffer (window-buffer w)
+      (when (overlayp vim-empty-lines-overlay)
+        (vim-empty-lines-update-overlay-aux
+         (vim-empty-lines-nlines-after-buffer-end w))))))
 
-(defun vim-empty-lines-update-overlay-aux (window)
-  (when (overlayp vim-empty-lines-overlay)
-    (let* ((nlines-after-buffer-end (vim-empty-lines-nlines-after-buffer-end window)))
-      (save-excursion
-        (when (> nlines-after-buffer-end 1)
-          (let ((indicators
-                 (apply 'concat
-                        (make-list nlines-after-buffer-end
-                                   (concat "\n" vim-empty-lines-indicator)))))
-            (overlay-put vim-empty-lines-overlay
-                         'after-string
-                         (concat (propertize " "
-                                             ;; Forbid movement past
-                                             ;; the beginning of the
-                                             ;; after-string.
-                                             'cursor nlines-after-buffer-end)
-                                 (propertize indicators
-                                             'face 'vim-empty-lines-face)))))))))
+(defun vim-empty-lines-update-overlay-aux (nlines-after-buffer-end)
+  (when (> nlines-after-buffer-end 1)
+    (save-excursion
+      (let ((indicators
+             (apply 'concat
+                    (make-list nlines-after-buffer-end
+                               (concat "\n" vim-empty-lines-indicator)))))
+        (overlay-put vim-empty-lines-overlay
+                     'after-string
+                     (concat (propertize " "
+                                         ;; Forbid movement past
+                                         ;; the beginning of the
+                                         ;; after-string.
+                                         'cursor nlines-after-buffer-end)
+                             (propertize indicators
+                                         'face 'vim-empty-lines-face)))))))
 
 (defun vim-empty-lines-hide-overlay ()
   (when (overlayp vim-empty-lines-overlay)

--- a/vim-empty-lines-mode.el
+++ b/vim-empty-lines-mode.el
@@ -137,7 +137,10 @@ Must not contain '\\n'."
     (with-current-buffer (window-buffer w)
       (when (overlayp vim-empty-lines-overlay)
         (vim-empty-lines-update-overlay-aux
-         (vim-empty-lines-nlines-after-buffer-end w))))))
+         (apply 'max
+                (vim-empty-lines-nlines-after-buffer-end w)
+                (mapcar 'vim-empty-lines-nlines-after-buffer-end
+                        (remq w (get-buffer-window-list nil nil t)))))))))
 
 (defun vim-empty-lines-update-overlay-aux (nlines-after-buffer-end)
   (when (> nlines-after-buffer-end 1)


### PR DESCRIPTION
`window-start' sometimes report outdated positions without
redisplay, it may or may not update the indicators. For emample,
- Open file bigger than `window-height' then do`beginning-of-buffer'.
- M-: (goto-char (point-max))
  ⇒ It sometimes does not draw the indicators because `window-start' == 1.

So hook `window-scroll-functions' to use a fresh display-start position.

Signed-off-by: Takeshi Banse takebi@laafc.net
