### PR TITLE
Avoid early set-buffer

### DIFF
--- a/vim-empty-lines-mode.el
+++ b/vim-empty-lines-mode.el
@@ -131,7 +131,7 @@ Must not contain '\\n'."
 
 (defun vim-empty-lines-update-overlay (&optional window _window-start)
   (let ((w (or window
-               (let ((w (get-buffer-window)))
+               (let ((w (selected-window)))
                  (and (window-valid-p w) w)))))
     ;; `w' could be nil but it's ok for `window-height', `window-start' etc.
     (with-current-buffer (window-buffer w)

--- a/vim-empty-lines-mode.el
+++ b/vim-empty-lines-mode.el
@@ -124,12 +124,6 @@ Must not contain '\\n'."
                                               t t))
   (overlay-put vim-empty-lines-overlay 'window t))
 
-(defun vim-empty-lines-nlines-after-buffer-end (window)
-  (with-current-buffer (window-buffer window)
-    (- (window-height window)
-       (- (line-number-at-pos (point-max))
-          (line-number-at-pos (window-start window))))))
-
 (defun vim-empty-lines-update-overlay (&optional window _window-start)
   (let ((w (or window
                (let ((w (selected-window)))
@@ -137,10 +131,10 @@ Must not contain '\\n'."
     ;; `w' could be nil but it's ok for `window-height', `window-start' etc.
     (when (overlayp vim-empty-lines-overlay)
       (vim-empty-lines-update-overlay-aux
-       (apply 'max
-              (vim-empty-lines-nlines-after-buffer-end w)
-              (mapcar 'vim-empty-lines-nlines-after-buffer-end
-                      (remq w (get-buffer-window-list nil nil t))))))))
+       (with-current-buffer (window-buffer w)
+         (- (window-height w)
+            (- (line-number-at-pos (point-max))
+               (line-number-at-pos (window-start w)))))))))
 
 (defun vim-empty-lines-update-overlay-aux (nlines-after-buffer-end)
   (when (> nlines-after-buffer-end 1)

--- a/vim-empty-lines-mode.el
+++ b/vim-empty-lines-mode.el
@@ -125,22 +125,22 @@ Must not contain '\\n'."
   (overlay-put vim-empty-lines-overlay 'window t))
 
 (defun vim-empty-lines-nlines-after-buffer-end (window)
-  (- (window-height window)
-     (- (line-number-at-pos (point-max))
-        (line-number-at-pos (window-start window)))))
+  (with-current-buffer (window-buffer window)
+    (- (window-height window)
+       (- (line-number-at-pos (point-max))
+          (line-number-at-pos (window-start window))))))
 
 (defun vim-empty-lines-update-overlay (&optional window _window-start)
   (let ((w (or window
                (let ((w (selected-window)))
                  (and (window-valid-p w) w)))))
     ;; `w' could be nil but it's ok for `window-height', `window-start' etc.
-    (with-current-buffer (window-buffer w)
-      (when (overlayp vim-empty-lines-overlay)
-        (vim-empty-lines-update-overlay-aux
-         (apply 'max
-                (vim-empty-lines-nlines-after-buffer-end w)
-                (mapcar 'vim-empty-lines-nlines-after-buffer-end
-                        (remq w (get-buffer-window-list nil nil t)))))))))
+    (when (overlayp vim-empty-lines-overlay)
+      (vim-empty-lines-update-overlay-aux
+       (apply 'max
+              (vim-empty-lines-nlines-after-buffer-end w)
+              (mapcar 'vim-empty-lines-nlines-after-buffer-end
+                      (remq w (get-buffer-window-list nil nil t))))))))
 
 (defun vim-empty-lines-update-overlay-aux (nlines-after-buffer-end)
   (when (> nlines-after-buffer-end 1)


### PR DESCRIPTION
I made a mistake that the cloned buffer does not have any indicators anymore.

For example:
switch-to-buffer "*scratch*" and `M-x clone-buffer` ⇒ The cloned buffer doesn't have any indicators.

Reorder the `with-current-buffer`…(`set-buffer` eventually) somehow fixes this in bf24853, and also fixes #5 in a better(?) way that it is not needed to check through same buffer windows in d1a99c1 .

I suspect that to `set-buffer` before updating the overlays which have the `window` property also triggers #5, but I'm not sure…
