### PR TITLE
Support narrowed buffers

### DIFF
--- a/vim-empty-lines-mode.el
+++ b/vim-empty-lines-mode.el
@@ -131,7 +131,7 @@ Must not contain '\\n'."
 
 (defun vim-empty-lines-update-overlay (&optional window _window-start)
   (let ((w (or window
-               (let ((w (get-buffer-window)))
+               (let ((w (selected-window)))
                  (and (window-valid-p w) w)))))
     ;; `w' could be nil but it's ok for `window-height', `window-start' etc.
     (with-current-buffer (window-buffer w)

--- a/vim-empty-lines-mode.el
+++ b/vim-empty-lines-mode.el
@@ -125,22 +125,22 @@ Must not contain '\\n'."
   (overlay-put vim-empty-lines-overlay 'window t))
 
 (defun vim-empty-lines-nlines-after-buffer-end (window)
-  (- (window-height window)
-     (- (line-number-at-pos (point-max))
-        (line-number-at-pos (window-start window)))))
+  (with-current-buffer (window-buffer window)
+    (- (window-height window)
+       (- (line-number-at-pos (point-max))
+          (line-number-at-pos (window-start window))))))
 
 (defun vim-empty-lines-update-overlay (&optional window _window-start)
   (let ((w (or window
                (let ((w (selected-window)))
                  (and (window-valid-p w) w)))))
     ;; `w' could be nil but it's ok for `window-height', `window-start' etc.
-    (with-current-buffer (window-buffer w)
-      (when (overlayp vim-empty-lines-overlay)
-        (vim-empty-lines-update-overlay-aux
-         (apply 'max
-                (vim-empty-lines-nlines-after-buffer-end w)
-                (mapcar 'vim-empty-lines-nlines-after-buffer-end
-                        (remq w (get-buffer-window-list nil nil t)))))))))
+    (when (overlayp vim-empty-lines-overlay)
+      (vim-empty-lines-update-overlay-aux
+       (apply 'max
+              (vim-empty-lines-nlines-after-buffer-end w)
+              (mapcar 'vim-empty-lines-nlines-after-buffer-end
+                      (remq w (get-buffer-window-list nil nil t))))))))
 
 (defun vim-empty-lines-update-overlay-aux (nlines-after-buffer-end)
   (when (> nlines-after-buffer-end 1)

--- a/vim-empty-lines-mode.el
+++ b/vim-empty-lines-mode.el
@@ -137,7 +137,8 @@ Must not contain '\\n'."
               `(defadvice ,function (around vim-empty-lines activate)
                  (if (not (overlayp vim-empty-lines-overlay))
                      ad-do-it
-                   (let ((p (overlay-start vim-empty-lines-overlay)))
+                   (let ((inhibit-redisplay t) ;; Hope not to break anything
+                         (p (overlay-start vim-empty-lines-overlay)))
                      (delete-overlay vim-empty-lines-overlay)
                      (unwind-protect ad-do-it
                        (move-overlay vim-empty-lines-overlay p p))))))


### PR DESCRIPTION
Using screen lines instead of line numbers to calculate the nlines allows to
support narrowed buffers.

Includes workaround for the both problems in #2 in commit 85a7d5bfeaf3257c9191e71e60e301e27663bea2.
The workaround is to advice to some emacs primitives. Advicing emacs primitives should be avoided, so the commit 85a7d5bfeaf3257c9191e71e60e301e27663bea2 could be dropped but I cannot find any other way.
